### PR TITLE
Add schedule copy feature to planning view

### DIFF
--- a/radiateur/templates/planning.html
+++ b/radiateur/templates/planning.html
@@ -26,16 +26,47 @@
             </div>
 
             <div class="planning-panel">
-                <div class="day-switcher">
-                    <button class="btn btn-outline-secondary day-switcher-btn" type="button" id="prevDay" aria-label="Jour précédent">
-                        <span aria-hidden="true">&larr;</span>
-                    </button>
-                    <div class="day-switcher-label text-center">
-                        <div class="fw-semibold" id="currentDayLabel">Lundi</div>
+                <div class="day-header">
+                    <div class="day-switcher">
+                        <button class="btn btn-outline-secondary day-switcher-btn" type="button" id="prevDay" aria-label="Jour précédent">
+                            <span aria-hidden="true">&larr;</span>
+                        </button>
+                        <div class="day-switcher-label text-center">
+                            <div class="fw-semibold" id="currentDayLabel">Lundi</div>
+                        </div>
+                        <button class="btn btn-outline-secondary day-switcher-btn" type="button" id="nextDay" aria-label="Jour suivant">
+                            <span aria-hidden="true">&rarr;</span>
+                        </button>
                     </div>
-                    <button class="btn btn-outline-secondary day-switcher-btn" type="button" id="nextDay" aria-label="Jour suivant">
-                        <span aria-hidden="true">&rarr;</span>
-                    </button>
+                    <div class="day-actions">
+                        <button
+                            class="btn btn-primary"
+                            type="button"
+                            id="copyDayButton"
+                            aria-haspopup="dialog"
+                            aria-expanded="false"
+                        >
+                            Copier vers…
+                        </button>
+                        <div
+                            class="copy-panel"
+                            id="copyPanel"
+                            role="dialog"
+                            aria-modal="true"
+                            aria-labelledby="copyPanelTitle"
+                            hidden
+                        >
+                            <div class="copy-panel-header" id="copyPanelTitle">Copier ce jour vers :</div>
+                            <p class="copy-panel-help">Sélectionnez les jours à mettre à jour. Leur programmation existante sera remplacée.</p>
+                            <form id="copyPanelForm" class="copy-panel-form">
+                                <div class="copy-panel-list" id="copyDayList"></div>
+                                <div class="copy-panel-actions">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="copyCancelButton">Annuler</button>
+                                    <button type="submit" class="btn btn-sm btn-primary">Copier</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="timeline-wrapper">
@@ -74,6 +105,12 @@
             const currentDayLabel = document.getElementById('currentDayLabel');
             const timelineWrapper = document.querySelector('.timeline-wrapper');
             const planningPanel = document.querySelector('.planning-panel');
+            const copyButton = document.getElementById('copyDayButton');
+            const copyPanel = document.getElementById('copyPanel');
+            const copyPanelForm = document.getElementById('copyPanelForm');
+            const copyPanelList = document.getElementById('copyDayList');
+            const copyPanelTitle = document.getElementById('copyPanelTitle');
+            const copyCancelButton = document.getElementById('copyCancelButton');
 
             let statusTimeout = null;
             let currentDayIndex = 0;
@@ -83,6 +120,7 @@
             let pixelsPerMinute = 1;
             let pendingTimelineRefresh = false;
             let autoSaveTimeout = null;
+            let copyPanelVisible = false;
 
             function showStatus(message, type = 'info', autoHide = true) {
                 statusToast.textContent = message;
@@ -226,6 +264,116 @@
                 scheduleBoard.dataset.day = DAYS[currentDayIndex].key;
                 prevButton.disabled = currentDayIndex === 0;
                 nextButton.disabled = currentDayIndex === DAYS.length - 1;
+                updateCopyPanelContent();
+            }
+
+            function updateCopyPanelContent() {
+                if (!copyPanelTitle || !copyButton) {
+                    return;
+                }
+                copyButton.setAttribute(
+                    'aria-label',
+                    `Copier la programmation du ${DAYS[currentDayIndex].label} vers d'autres jours`,
+                );
+                copyPanelTitle.textContent = `Copier ${DAYS[currentDayIndex].label} vers :`;
+                if (!copyPanelList) {
+                    return;
+                }
+                if (!copyPanelVisible) {
+                    copyPanelList.innerHTML = '';
+                } else {
+                    populateCopyPanelList();
+                }
+            }
+
+            function populateCopyPanelList() {
+                if (!copyPanelList) {
+                    return;
+                }
+                copyPanelList.innerHTML = '';
+                DAYS.forEach((day, index) => {
+                    if (index === currentDayIndex) {
+                        return;
+                    }
+                    const checkboxId = `copy-${day.key}`;
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'form-check copy-option';
+
+                    const input = document.createElement('input');
+                    input.className = 'form-check-input';
+                    input.type = 'checkbox';
+                    input.name = 'copyDay';
+                    input.value = day.key;
+                    input.id = checkboxId;
+
+                    const label = document.createElement('label');
+                    label.className = 'form-check-label';
+                    label.setAttribute('for', checkboxId);
+                    label.textContent = day.label;
+
+                    wrapper.appendChild(input);
+                    wrapper.appendChild(label);
+                    copyPanelList.appendChild(wrapper);
+                });
+            }
+
+            let copyOutsideHandler = null;
+            let copyEscapeHandler = null;
+
+            function closeCopyPanel() {
+                if (!copyPanel || !copyButton) {
+                    return;
+                }
+                copyPanelVisible = false;
+                copyPanel.setAttribute('hidden', '');
+                copyPanel.classList.remove('copy-panel-visible');
+                copyButton.setAttribute('aria-expanded', 'false');
+                if (copyOutsideHandler) {
+                    document.removeEventListener('pointerdown', copyOutsideHandler, true);
+                    copyOutsideHandler = null;
+                }
+                if (copyEscapeHandler) {
+                    document.removeEventListener('keydown', copyEscapeHandler, true);
+                    copyEscapeHandler = null;
+                }
+            }
+
+            function openCopyPanel() {
+                if (!copyPanel || !copyButton) {
+                    return;
+                }
+                populateCopyPanelList();
+                copyPanelVisible = true;
+                copyPanel.removeAttribute('hidden');
+                copyPanel.classList.add('copy-panel-visible');
+                copyButton.setAttribute('aria-expanded', 'true');
+                copyOutsideHandler = (event) => {
+                    if (!copyPanelVisible) {
+                        return;
+                    }
+                    if (
+                        copyPanel.contains(event.target)
+                        || copyButton.contains(event.target)
+                    ) {
+                        return;
+                    }
+                    closeCopyPanel();
+                };
+                copyEscapeHandler = (event) => {
+                    if (event.key === 'Escape') {
+                        closeCopyPanel();
+                    }
+                };
+                document.addEventListener('pointerdown', copyOutsideHandler, true);
+                document.addEventListener('keydown', copyEscapeHandler, true);
+            }
+
+            function toggleCopyPanel() {
+                if (copyPanelVisible) {
+                    closeCopyPanel();
+                } else {
+                    openCopyPanel();
+                }
             }
 
             function updateSlotElement(block, startMinutes, endMinutes) {
@@ -668,6 +816,44 @@
                     renderCurrentDay();
                 }
             });
+
+            if (copyButton && copyPanel && copyPanelForm && copyCancelButton) {
+                copyButton.addEventListener('click', () => {
+                    toggleCopyPanel();
+                });
+
+                copyCancelButton.addEventListener('click', () => {
+                    closeCopyPanel();
+                });
+
+                copyPanelForm.addEventListener('submit', (event) => {
+                    event.preventDefault();
+                    const sourceDayKey = DAYS[currentDayIndex].key;
+                    const targets = Array.from(
+                        copyPanelForm.querySelectorAll('input[name="copyDay"]:checked'),
+                    ).map((input) => input.value);
+
+                    if (targets.length === 0) {
+                        showStatus('Sélectionnez au moins un jour pour copier la programmation.', 'warning');
+                        return;
+                    }
+
+                    const sourceSlots = currentSchedule[sourceDayKey] || [];
+                    targets.forEach((dayKey) => {
+                        currentSchedule[dayKey] = sourceSlots.map((slot) => ({
+                            start: slot.start,
+                            end: slot.end,
+                        }));
+                    });
+
+                    if (targets.includes(sourceDayKey)) {
+                        renderCurrentDay();
+                    }
+
+                    closeCopyPanel();
+                    persistSchedule('Programmations copiées et enregistrées.', 'Copie en cours…');
+                });
+            }
 
             const rawSchedule = JSON.parse(document.getElementById('schedule-data').textContent || '{}');
             let currentSchedule = ensureScheduleStructure(rawSchedule);

--- a/radiateur/templates/planning.html
+++ b/radiateur/templates/planning.html
@@ -14,15 +14,8 @@
     <body class="bg-light">
         <script id="schedule-data" type="application/json">{{ data|safe }}</script>
         <div class="container py-4 planning-container">
-            <div class="d-flex flex-column gap-3 gap-md-4 mb-4">
-                <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-3">
-                    <div>
-                        <h1 class="h3 mb-0">Planning hebdomadaire</h1>
-                    </div>
-                    <div class="d-flex flex-column flex-sm-row gap-2 w-100 w-md-auto">
-                        <a class="btn btn-outline-secondary flex-fill" href="/">Retour au tableau de bord</a>
-                    </div>
-                </div>
+            <div class="d-flex justify-content-md-end mb-4">
+                <a class="btn btn-outline-secondary w-100 w-md-auto" href="/">Retour au tableau de bord</a>
             </div>
 
             <div class="planning-panel">

--- a/static/css/planning.css
+++ b/static/css/planning.css
@@ -74,6 +74,15 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
+    position: relative;
+}
+
+.day-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+    flex-wrap: wrap;
 }
 
 .day-switcher {
@@ -81,6 +90,67 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+}
+
+.day-actions {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.day-actions > .btn {
+    white-space: nowrap;
+}
+
+.copy-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    background: #fff;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 0.9rem;
+    padding: 1rem;
+    min-width: min(260px, 90vw);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+    z-index: 1010;
+}
+
+.copy-panel-visible {
+    display: block;
+}
+
+.copy-panel-header {
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.copy-panel-help {
+    font-size: 0.85rem;
+    color: #6c757d;
+    margin-bottom: 0.75rem;
+}
+
+.copy-panel-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 220px;
+    overflow-y: auto;
+    margin-bottom: 0.75rem;
+}
+
+.copy-option .form-check-label {
+    cursor: pointer;
+}
+
+.copy-panel-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.copy-panel-actions .btn {
+    min-width: 90px;
 }
 
 .day-switcher-btn {
@@ -226,6 +296,17 @@ body {
 }
 
 @media (max-width: 576px) {
+    .day-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .day-actions {
+        align-self: stretch;
+        justify-content: flex-start;
+    }
+
     .planning-panel {
         padding: 1.25rem 1rem 1.5rem;
         border-radius: 1rem;

--- a/static/css/planning.css
+++ b/static/css/planning.css
@@ -9,7 +9,6 @@
 html,
 body {
     height: 100%;
-    overflow: hidden;
 }
 
 body {
@@ -17,6 +16,7 @@ body {
     background: #f8f9fa;
     touch-action: manipulation;
     overscroll-behavior: none;
+    overflow-x: hidden;
 }
 
 .planning-container {
@@ -305,6 +305,17 @@ body {
     .day-actions {
         align-self: stretch;
         justify-content: flex-start;
+        width: 100%;
+    }
+
+    .copy-panel {
+        position: fixed;
+        inset: auto 1rem 1.25rem 1rem;
+        min-width: 0;
+        width: calc(100vw - 2rem);
+        max-height: min(70vh, 420px);
+        overflow-y: auto;
+        border-radius: 1rem;
     }
 
     .planning-panel {


### PR DESCRIPTION
## Summary
- add a copy control and dialog to the planning page so a day's programme can be duplicated to other days
- implement client-side logic to duplicate slots, persist the changes, and provide feedback
- style the new controls for desktop and mobile layouts

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68e3c59fc4048320a67c718c422833ac