### PR TITLE
Improve ESP discovery and add status LED patterns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==5.0.1
 paho-mqtt
 pytz
 python-dotenv
+netifaces


### PR DESCRIPTION
## Summary
- broaden the ESP8266 discovery scan by using all local IPv4 networks, prioritising saved device IPs and capping the number of probed hosts
- add the netifaces dependency required for interface inspection during discovery
- implement non-blocking LED patterns on the ESP8266 to indicate Wi-Fi, Django configuration, and MQTT connectivity states

## Testing
- python -m compileall radiateur

------
https://chatgpt.com/codex/tasks/task_e_68e6ec6ff8548320b94b1c66c01d76bb