### PR TITLE
Serve service worker from root and replace binary PWA assets

### DIFF
--- a/radiateur/templates/index.html
+++ b/radiateur/templates/index.html
@@ -5,6 +5,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Contrôle Domotique</title>
+    <link rel="icon" type="image/svg+xml" sizes="any" href="{% static 'img/pwa-icon.svg' %}">
+    <link rel="apple-touch-icon" href="{% static 'img/pwa-icon.svg' %}">
+    <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
+    <meta name="theme-color" content="#1b4965">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static 'css/mobiscroll.javascript.min.css' %}">
     <script src="{% static 'js/mobiscroll.javascript.min.js' %}"></script>
@@ -330,5 +336,6 @@
     demanderEtat();
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="{% static 'js/pwa-init.js' %}"></script>
 </body>
 </html>

--- a/radiateur/templates/options.html
+++ b/radiateur/templates/options.html
@@ -5,6 +5,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Options</title>
+    <link rel="icon" type="image/svg+xml" sizes="any" href="{% static 'img/pwa-icon.svg' %}">
+    <link rel="apple-touch-icon" href="{% static 'img/pwa-icon.svg' %}">
+    <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
+    <meta name="theme-color" content="#1b4965">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static 'css/index.css' %}">
 </head>
@@ -298,5 +304,6 @@
     });
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="{% static 'js/pwa-init.js' %}"></script>
 </body>
 </html>

--- a/radiateur/templates/planning.html
+++ b/radiateur/templates/planning.html
@@ -8,6 +8,12 @@
             content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
         >
         <title>Contrôle radiateur - Planning</title>
+        <link rel="icon" type="image/svg+xml" sizes="any" href="{% static 'img/pwa-icon.svg' %}">
+        <link rel="apple-touch-icon" href="{% static 'img/pwa-icon.svg' %}">
+        <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
+        <meta name="theme-color" content="#1b4965">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="default">
         <link rel="stylesheet" href="{% static 'bootstrap-5.3.8-dist/css/bootstrap.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/planning.css' %}">
     </head>
@@ -865,5 +871,6 @@
                 panelObserver.observe(planningPanel);
             }
         </script>
+        <script src="{% static 'js/pwa-init.js' %}"></script>
     </body>
 </html>

--- a/radiateur/urls.py
+++ b/radiateur/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import path
 
 from . import views
 
@@ -11,5 +11,6 @@ urlpatterns = [
     path("devices/", views.devices, name="devices"),
     # path("getjson/", views.getjson, name="datajson"),
     path("maj_json", views.maj_json, name="maj_json"),
+    path("service-worker.js", views.service_worker, name="service-worker"),
     # path("get_image_url/", views.get_image_url, name="get_image_url")
 ]

--- a/static/img/pwa-icon.svg
+++ b/static/img/pwa-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1b4965" />
+      <stop offset="100%" stop-color="#3282b8" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#grad)" />
+  <g fill="#ffffff" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700">
+    <text x="50%" y="54%" font-size="192" text-anchor="middle" dominant-baseline="middle">DR</text>
+    <text x="50%" y="76%" font-size="72" text-anchor="middle" dominant-baseline="middle">domotique</text>
+  </g>
+</svg>

--- a/static/js/pwa-init.js
+++ b/static/js/pwa-init.js
@@ -1,0 +1,12 @@
+(function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .catch((error) => {
+        console.error('Service worker registration failed:', error);
+      });
+  });
+})();

--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -1,0 +1,78 @@
+const CACHE_NAME = 'domotique-radiateur-v2';
+const OFFLINE_URLS = [
+  '/',
+  '/planning/',
+  '/options/',
+  '/static/css/index.css',
+  '/static/css/mobiscroll.javascript.min.css',
+  '/static/js/mobiscroll.javascript.min.js',
+  '/static/js/pwa-init.js',
+  '/static/manifest.webmanifest',
+  '/static/img/pwa-icon.svg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET' || !request.url.startsWith(self.location.origin)) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cachedPage) => {
+            if (cachedPage) {
+              return cachedPage;
+            }
+            return caches.match('/') || caches.match('/index.html');
+          })
+        )
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match(request));
+    })
+  );
+});

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Domotique Radiateur",
+  "short_name": "Radiateurs",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f0f4f8",
+  "theme_color": "#1b4965",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "/static/img/pwa-icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/img/pwa-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the PWA icon PNGs with a single reusable SVG and update each template to reference it
- expose the service worker script from the project root and register it from the client for full-site scope
- refresh the manifest configuration and offline caching strategy to cover the main views

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68e8eb380120832096c52c0c77d1d089