### PR TITLE
Add persistent authentication for the radiator dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ python manage.py migrate
 python manage.py createsuperuser
 ```
 
+Utilisez ensuite ce compte pour vous connecter à l'interface Web via
+`http://<IP_du_Pi>:8000/login/`. Une session reste active pendant 30 jours et
+est prolongée automatiquement à chaque visite, ce qui évite d'avoir à se
+réauthentifier à chaque utilisation. Pensez à vous déconnecter depuis le menu
+"Déconnexion" si vous utilisez un appareil partagé.
+
 ## 6. Démarrage du courtier Mosquitto
 Le paquet `mosquitto` installe un service systemd. Pour le démarrer et l'activer au démarrage :
 ```bash

--- a/djangoProject1/settings.py
+++ b/djangoProject1/settings.py
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'radiateur.middleware.LoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -140,6 +141,13 @@ MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 LOGIN_URL = "login"
 LOGIN_REDIRECT_URL = "index"
 LOGOUT_REDIRECT_URL = "login"
+
+LOGIN_EXEMPT_URLS = (
+    "/login/",
+    "/logout/",
+    "/admin/*",
+    "/service-worker.js",
+)
 
 # Keep authenticated sessions active for a long period so users
 # do not need to sign in repeatedly.

--- a/djangoProject1/settings.py
+++ b/djangoProject1/settings.py
@@ -136,6 +136,17 @@ MEDIA_URL = os.getenv("MEDIA_URL", "/media/")
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASE_DIR, "media"))
 
 
+# Authentication settings
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "index"
+LOGOUT_REDIRECT_URL = "login"
+
+# Keep authenticated sessions active for a long period so users
+# do not need to sign in repeatedly.
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 30  # 30 days
+SESSION_SAVE_EVERY_REQUEST = True
+
+
 # Application specific settings
 APP_TIMEZONE = os.getenv("APP_TIMEZONE", "Europe/Paris")
 MQTT_BROKER_HOST = os.getenv("MQTT_BROKER_HOST", "127.0.0.1")

--- a/djangoProject1/urls.py
+++ b/djangoProject1/urls.py
@@ -15,9 +15,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.contrib.auth.views import LogoutView
+from django.urls import include, path
+
+from radiateur.auth import PersistentLoginView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('login/', PersistentLoginView.as_view(), name='login'),
+    path('logout/', LogoutView.as_view(), name='logout'),
     path("", include("radiateur.urls"))
 ]

--- a/radiateur/auth.py
+++ b/radiateur/auth.py
@@ -1,0 +1,18 @@
+"""Authentication views for the radiateur application."""
+
+from django.conf import settings
+from django.contrib.auth.views import LoginView
+
+
+class PersistentLoginView(LoginView):
+    """Login view keeping the session active for an extended period."""
+
+    redirect_authenticated_user = True
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        # Refresh the session expiry so authenticated users can stay logged in
+        # as long as they use the interface regularly.
+        self.request.session.set_expiry(settings.SESSION_COOKIE_AGE)
+        return response
+

--- a/radiateur/middleware.py
+++ b/radiateur/middleware.py
@@ -1,0 +1,46 @@
+"""Custom middleware enforcing authentication across the dashboard."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+
+from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
+from django.http import HttpRequest, HttpResponse
+
+
+class LoginRequiredMiddleware:
+    """Redirect anonymous users to the login page for protected URLs."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        exempt = getattr(settings, "LOGIN_EXEMPT_URLS", ())
+        self.exempt_patterns: tuple[str, ...] = tuple(exempt)
+
+    def _is_exempt(self, path: str) -> bool:
+        if not path:
+            return False
+
+        static_url = getattr(settings, "STATIC_URL", None) or ""
+        if static_url and path.startswith(static_url):
+            return True
+
+        media_url = getattr(settings, "MEDIA_URL", None) or ""
+        if media_url and path.startswith(media_url):
+            return True
+
+        for pattern in self.exempt_patterns:
+            if fnmatch(path, pattern):
+                return True
+
+        return False
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        if request.user.is_authenticated:
+            return self.get_response(request)
+
+        path = request.path_info
+        if self._is_exempt(path):
+            return self.get_response(request)
+
+        return redirect_to_login(path)

--- a/radiateur/templates/index.html
+++ b/radiateur/templates/index.html
@@ -29,11 +29,17 @@
 {{ disabled_states|json_script:'radiator-disabled' }}
 
 <div class="container-fluid main-panel py-3">
-    <div class="d-flex align-items-center justify-content-between mb-3">
-        <h1 class="h5 text-dark mb-0">Contrôle</h1>
-        <div class="d-flex gap-2">
-            <button id="boutonPlanning" type="button" class="btn btn-outline-primary btn-icon">Planning</button>
-            <button id="boutonOption" type="button" class="btn btn-outline-secondary btn-icon">Options</button>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+        <div class="d-flex align-items-center flex-wrap gap-2">
+            <h1 class="h5 text-dark mb-0">Contrôle</h1>
+            <span class="badge text-bg-light border border-secondary-subtle text-muted">Connecté en tant que {{ request.user.get_username }}</span>
+        </div>
+        <div class="d-flex align-items-center flex-wrap gap-2">
+            <div class="d-flex gap-2">
+                <button id="boutonPlanning" type="button" class="btn btn-outline-primary btn-icon">Planning</button>
+                <button id="boutonOption" type="button" class="btn btn-outline-secondary btn-icon">Options</button>
+            </div>
+            <a href="{% url 'logout' %}" class="btn btn-outline-danger btn-icon">Déconnexion</a>
         </div>
     </div>
 

--- a/radiateur/tests.py
+++ b/radiateur/tests.py
@@ -1,3 +1,57 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class AuthenticationTests(TestCase):
+    """Verify that the dashboard requires a valid authenticated session."""
+
+    def setUp(self) -> None:
+        self.password = "super-secret"
+        self.user = get_user_model().objects.create_user(
+            username="radiateur", password=self.password
+        )
+
+    def test_anonymous_user_is_redirected(self) -> None:
+        """Protected views should redirect anonymous visitors to the login page."""
+
+        protected_urls = [
+            reverse("index"),
+            reverse("planning"),
+            reverse("options"),
+            reverse("devices"),
+        ]
+
+        for url in protected_urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 302)
+                self.assertIn(reverse("login"), response.url)
+
+    def test_authenticated_user_can_access_dashboard(self) -> None:
+        """A valid user should be able to open the dashboard."""
+
+        logged_in = self.client.login(username=self.user.username, password=self.password)
+        self.assertTrue(logged_in)
+
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.user.get_username())
+
+    def test_successful_login_sets_expected_session_expiry(self) -> None:
+        """Logging in refreshes the session expiry to the configured duration."""
+
+        response = self.client.post(
+            reverse("login"),
+            {"username": self.user.username, "password": self.password},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        expiry = self.client.session.get_expiry_age()
+        self.assertAlmostEqual(
+            expiry,
+            settings.SESSION_COOKIE_AGE,
+            delta=5,
+        )

--- a/radiateur/views.py
+++ b/radiateur/views.py
@@ -13,6 +13,7 @@ import http.client
 from pathlib import Path
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
@@ -185,6 +186,7 @@ def _validate_schedule(payload: object) -> dict[str, list[dict[str, str]]]:
 
 @csrf_exempt
 @never_cache
+@login_required
 def planning(request):
     """Render the planning page along with the JSON payload."""
 
@@ -214,6 +216,7 @@ def service_worker(request):
 
 
 @csrf_exempt
+@login_required
 def index(request):
     """Render the main dashboard page."""
 
@@ -238,6 +241,7 @@ def index(request):
 
 @csrf_exempt
 @never_cache
+@login_required
 def maj_json(request):
     """Persist the planning JSON received from the front-end."""
 
@@ -255,6 +259,7 @@ def maj_json(request):
 
 
 @csrf_exempt
+@login_required
 def changement_etat(request):
     """Handle state change requests sent from the UI."""
 
@@ -289,6 +294,7 @@ def changement_etat(request):
 
 
 @csrf_exempt
+@login_required
 def retourner_etat(request):
     """Return the latest device states after requesting them from MQTT."""
 
@@ -303,6 +309,7 @@ def retourner_etat(request):
 
 
 @csrf_exempt
+@login_required
 def options(request):
     """Display and update the options page allowing per-radiator overrides."""
 
@@ -654,6 +661,7 @@ def _push_mqtt_host(ip: str, host: str) -> bool:
 
 @csrf_exempt
 @never_cache
+@login_required
 def devices(request):
     """Manage ESP8266 registrations via the JSON registry."""
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,50 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Connexion &mdash; Domotique radiateur</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="{% static 'img/pwa-icon.svg' %}">
+</head>
+<body class="bg-light d-flex align-items-center" style="min-height: 100vh;">
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-5">
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4 p-lg-5">
+                    <h1 class="h4 text-center mb-4">Connexion</h1>
+                    {% if form.errors %}
+                        <div class="alert alert-danger" role="alert">
+                            Identifiants incorrects. Veuillez réessayer.
+                        </div>
+                    {% endif %}
+                    {% if next and user.is_authenticated %}
+                        <div class="alert alert-info" role="alert">
+                            Vous êtes déjà connecté.
+                        </div>
+                    {% endif %}
+                    <form method="post" novalidate>
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ next }}">
+                        <div class="mb-3">
+                            <label for="id_username" class="form-label">Nom d'utilisateur</label>
+                            <input type="text" name="username" autofocus required class="form-control" id="id_username" value="{{ form.username.value|default:'' }}">
+                        </div>
+                        <div class="mb-4">
+                            <label for="id_password" class="form-label">Mot de passe</label>
+                            <input type="password" name="password" required class="form-control" id="id_password">
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Se connecter</button>
+                    </form>
+                    <p class="text-muted small mt-4 mb-0 text-center">
+                        Vous resterez connecté pendant 30&nbsp;jours sur cet appareil. Pensez à vous déconnecter sur un poste partagé.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a persistent login view with long-lived sessions and register login/logout URLs
- protect dashboard endpoints with authentication and expose logout controls in the UI
- add a styled login page and document how to connect to the interface

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68e953860a048320aeff67b86eb8607a