### PR TITLE
Preload cached radiator state on dashboard load

### DIFF
--- a/radiateur/templates/index.html
+++ b/radiateur/templates/index.html
@@ -27,6 +27,7 @@
 
 {{ radiators|json_script:'radiator-list' }}
 {{ disabled_states|json_script:'radiator-disabled' }}
+{{ initial_states|json_script:'radiator-states' }}
 
 <div class="container-fluid main-panel py-3">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
@@ -109,6 +110,7 @@
 <script>
     const radiators = JSON.parse(document.getElementById('radiator-list').textContent || '[]');
     const disabledInitial = JSON.parse(document.getElementById('radiator-disabled').textContent || '{}');
+    const statesInitial = JSON.parse(document.getElementById('radiator-states').textContent || '{}');
     const iconCache = {};
     document.querySelectorAll('.image-cache').forEach((element) => {
         iconCache[element.dataset.mode] = element.dataset.imageUrl;
@@ -338,7 +340,7 @@
         window.location.href = '/options/';
     });
 
-    applyStateSnapshot({}, disabledStates);
+    applyStateSnapshot(statesInitial, disabledStates);
     demanderEtat();
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>

--- a/radiateur/views.py
+++ b/radiateur/views.py
@@ -223,6 +223,7 @@ def index(request):
     enregistrer_log("Requete page 'index'")
     radiators = get_all_radiator_names()
     disabled_states = load_disabled_states()
+    cached_states = get_cached_states()
     radiator_cards: list[tuple[str, bool]] = []
     has_active_radiators = False
     for radiator in radiators:
@@ -233,6 +234,7 @@ def index(request):
     context = {
         "radiators": radiators,
         "disabled_states": disabled_states,
+        "initial_states": cached_states,
         "radiator_cards": radiator_cards,
         "has_active_radiators": has_active_radiators,
     }


### PR DESCRIPTION
## Summary
- include the cached radiator states in the dashboard context
- hydrate the dashboard UI with the cached states to avoid the initial error state flicker

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e95a8f4ee88320b774ccb836da61f3