### PR TITLE
Shorten MQTT state refresh roundtrip

### DIFF
--- a/radiateur/services.py
+++ b/radiateur/services.py
@@ -281,7 +281,12 @@ def boucle_demander_etat_appareil(
         time.sleep(delai)
 
 
-def demander_etat_au_appareil(mqtt_client, nb_try: int = 1, liste_radiateur: Iterable[str] | None = None):
+def demander_etat_au_appareil(
+    mqtt_client,
+    nb_try: int = 1,
+    liste_radiateur: Iterable[str] | None = None,
+    timeout: float = 2.0,
+):
     """Request the state of each radiator and update the shared cache."""
 
     if not mqtt_client:
@@ -331,10 +336,12 @@ def demander_etat_au_appareil(mqtt_client, nb_try: int = 1, liste_radiateur: Ite
         if all(reponse_obtenu.values()):
             return 1
 
-        if time.time() - start_time > 2:
-            liste_radiateur_sans_retour = [cle for cle, value in reponse_obtenu.items() if not value]
+        if time.time() - start_time > timeout:
+            liste_radiateur_sans_retour = [
+                cle for cle, value in reponse_obtenu.items() if not value
+            ]
             return demander_etat_au_appareil(
-                mqtt_client, nb_try + 1, liste_radiateur_sans_retour
+                mqtt_client, nb_try + 1, liste_radiateur_sans_retour, timeout
             )
 
         old_nb_message = new_nb_message

--- a/radiateur/templates/index.html
+++ b/radiateur/templates/index.html
@@ -27,6 +27,7 @@
 
 {{ radiators|json_script:'radiator-list' }}
 {{ disabled_states|json_script:'radiator-disabled' }}
+{{ initial_states|json_script:'radiator-states' }}
 
 <div class="container-fluid main-panel py-3">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
@@ -109,6 +110,7 @@
 <script>
     const radiators = JSON.parse(document.getElementById('radiator-list').textContent || '[]');
     const disabledInitial = JSON.parse(document.getElementById('radiator-disabled').textContent || '{}');
+    const statesInitial = JSON.parse(document.getElementById('radiator-states').textContent || '{}');
     const iconCache = {};
     document.querySelectorAll('.image-cache').forEach((element) => {
         iconCache[element.dataset.mode] = element.dataset.imageUrl;
@@ -338,7 +340,7 @@
         window.location.href = '/options/';
     });
 
-    applyStateSnapshot({}, disabledStates);
+    applyStateSnapshot(statesInitial, disabledStates);
     demanderEtat();
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>

--- a/radiateur/views.py
+++ b/radiateur/views.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import math
 import socket
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from ipaddress import ip_address, ip_network
@@ -223,6 +222,7 @@ def index(request):
     enregistrer_log("Requete page 'index'")
     radiators = get_all_radiator_names()
     disabled_states = load_disabled_states()
+    cached_states = get_cached_states()
     radiator_cards: list[tuple[str, bool]] = []
     has_active_radiators = False
     for radiator in radiators:
@@ -233,6 +233,7 @@ def index(request):
     context = {
         "radiators": radiators,
         "disabled_states": disabled_states,
+        "initial_states": cached_states,
         "radiator_cards": radiator_cards,
         "has_active_radiators": has_active_radiators,
     }
@@ -303,8 +304,7 @@ def retourner_etat(request):
         enregistrer_log("Impossible de retourner l'état: client MQTT indisponible")
         return JsonResponse({"states": get_cached_states(), "disabled": load_disabled_states()})
 
-    demander_etat_au_appareil(client)
-    time.sleep(0.05)
+    demander_etat_au_appareil(client, timeout=0.6)
     return JsonResponse({"states": get_cached_states(), "disabled": load_disabled_states()})
 
 


### PR DESCRIPTION
## Summary
- allow the MQTT state polling helper to accept a configurable timeout
- have the dashboard refresh endpoint use a shorter timeout so the AJAX call returns faster

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e95a8f4ee88320b774ccb836da61f3